### PR TITLE
ch2: Add project for SmartSearch

### DIFF
--- a/ch02/SmartSearch/Program.cs
+++ b/ch02/SmartSearch/Program.cs
@@ -12,18 +12,21 @@ namespace SmartSearch
         };
         static void Main(string[] args)
         {
-            var sd = new SmartDDictionary<string>(m => m, fruits);
+            var sd = new SmartDictionary<string>(m => m, fruits);
             bool finished = false;
             while(!finished)
             {
+                Console.Write("Search for fruit: ");
                 var search = Console.ReadLine();
                 Console.WriteLine();
                 foreach (var fruit in sd.Search(search, 5))
                 {
                     Console.WriteLine(fruit);
                 }
-                Console.WriteLine("finished ?");
+                Console.WriteLine();
+                Console.Write("finished (y = yes)?: ");
                 finished = (Console.ReadKey().KeyChar == 'y');
+                Console.WriteLine();
             }
         }
     }

--- a/ch02/SmartSearch/SmartDictionary.cs
+++ b/ch02/SmartSearch/SmartDictionary.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace SmartSearch
 {
-    public class SmartDDictionary<T>
+    public class SmartDictionary<T>
     {
         private List<T> allItems;
         private Func<T, string> keyAccessor;
@@ -15,7 +15,7 @@ namespace SmartSearch
             public double Penalty=0;
             public int FoundChars=0;
         }
-        public SmartDDictionary(Func<T, string> keyAccessor, IEnumerable<T> allItems)
+        public SmartDictionary(Func<T, string> keyAccessor, IEnumerable<T> allItems)
         {
             if (allItems == null) throw new ArgumentNullException(nameof(allItems));
             this.keyAccessor = keyAccessor ?? throw new ArgumentNullException(nameof(keyAccessor));

--- a/ch02/SmartSearch/SmartSearch.csproj
+++ b/ch02/SmartSearch/SmartSearch.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/ch02/SmartSearch/readme.txt
+++ b/ch02/SmartSearch/readme.txt
@@ -1,2 +1,0 @@
-Create a dotnetcore consolle application and copy the SmartSearch folder content
-into the project folder. See "Designing a fast selection logic" subsection in chapter 2  

--- a/ch02/ch02.sln
+++ b/ch02/ch02.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30404.54
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "scalability-sample-2E", "scalability-sample-2E\scalability-sample-2E.csproj", "{EC3D0F71-E0FC-466E-B764-C96CACBD1530}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "scalability-sample-2E", "scalability-sample-2E\scalability-sample-2E.csproj", "{EC3D0F71-E0FC-466E-B764-C96CACBD1530}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartSearch", "SmartSearch\SmartSearch.csproj", "{C704A3AC-7BCF-4F8B-A78A-2F6600913063}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{EC3D0F71-E0FC-466E-B764-C96CACBD1530}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC3D0F71-E0FC-466E-B764-C96CACBD1530}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC3D0F71-E0FC-466E-B764-C96CACBD1530}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C704A3AC-7BCF-4F8B-A78A-2F6600913063}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C704A3AC-7BCF-4F8B-A78A-2F6600913063}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C704A3AC-7BCF-4F8B-A78A-2F6600913063}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C704A3AC-7BCF-4F8B-A78A-2F6600913063}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Adds a .csproj for `SmartSearch` and includes it in the .sln.
- Removes `readme.txt` now that the instructions are no longer needed.
- Renames `SmartDDictionary` to `SmartDictionary`.
- Outputs hints to the user when running the `SmartSearch` console application to:
  - Make it clear that input is required.
  - Show that `y` can be used to exit the program.