### PR TITLE
Restore missing Packages/*.cs files removed in previous cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,7 @@ PublishScripts/
 *.snupkg
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
+!**/[Pp]ackages/*.cs
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
 # Uncomment if necessary however generally it will be regenerated when needed

--- a/ch15/PackagesManagement/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
+++ b/ch15/PackagesManagement/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
@@ -1,0 +1,45 @@
+using PackagesManagementDomain.Aggregates;
+using PackagesManagementDomain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageFullEditViewModel: IPackageFullEditDTO
+    {
+        public PackageFullEditViewModel() { }
+        public PackageFullEditViewModel(IPackage o)
+        {
+            Id = o.Id;
+            DestinationId = o.DestinationId;
+            Name = o.Name;
+            Description = o.Description;
+            Price = o.Price;
+            DurationInDays = o.DurationInDays;
+            StartValidityDate = o.StartValidityDate;
+            EndValidityDate = o.EndValidityDate;
+        }
+        public int Id { get; set; }
+        [StringLength(128, MinimumLength = 5), Required]
+        [Display(Name = "name")]
+        public string Name { get; set; }
+        [Display(Name = "package infos")]
+        [StringLength(128, MinimumLength = 10), Required]
+        public string Description { get; set; }
+        [Display(Name = "price")]
+        [Range(0, 100000)]
+        public decimal Price { get; set; }
+        [Display(Name = "duration in days")]
+        [Range(1, 90)]
+        public int DurationInDays { get; set; }
+        [Display(Name = "available from"), Required]
+        public DateTime? StartValidityDate { get; set; }
+        [Display(Name = "available to"), Required]
+        public DateTime? EndValidityDate { get; set; }
+        [Display(Name = "destination")]
+        public int DestinationId { get; set; }
+    }
+}

--- a/ch15/PackagesManagement/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
+++ b/ch15/PackagesManagement/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
@@ -1,0 +1,25 @@
+using PackagesManagementDomain.Aggregates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageInfosViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public int DurationInDays { get; set; }
+        public DateTime? StartValidityDate { get; set; }
+        public DateTime? EndValidityDate { get; set; }
+        public string DestinationName { get; set; }
+        public int DestinationId { get; set; }
+        public override string ToString()
+        {
+            return string.Format("{0}. {1} days in {2}, price: {3}",
+                Name, DurationInDays, DestinationName, Price);
+        }
+    }
+}

--- a/ch15/PackagesManagement/PackagesManagement/Models/Packages/PackagesListViewModel.cs
+++ b/ch15/PackagesManagement/PackagesManagement/Models/Packages/PackagesListViewModel.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackagesListViewModel
+    {
+        public IEnumerable<PackageInfosViewModel> Items { get; set; }
+    }
+}

--- a/ch16/PackagesManagementBlazor/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
+++ b/ch16/PackagesManagementBlazor/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
@@ -1,0 +1,45 @@
+using PackagesManagementDomain.Aggregates;
+using PackagesManagementDomain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageFullEditViewModel: IPackageFullEditDTO
+    {
+        public PackageFullEditViewModel() { }
+        public PackageFullEditViewModel(IPackage o)
+        {
+            Id = o.Id;
+            DestinationId = o.DestinationId;
+            Name = o.Name;
+            Description = o.Description;
+            Price = o.Price;
+            DuratioInDays = o.DuratioInDays;
+            StartValidityDate = o.StartValidityDate;
+            EndValidityDate = o.EndValidityDate;
+        }
+        public int Id { get; set; }
+        [StringLength(128, MinimumLength = 5), Required]
+        [Display(Name = "name")]
+        public string Name { get; set; }
+        [Display(Name = "package infos")]
+        [StringLength(128, MinimumLength = 10), Required]
+        public string Description { get; set; }
+        [Display(Name = "price")]
+        [Range(0, 100000)]
+        public decimal Price { get; set; }
+        [Display(Name = "duration in days")]
+        [Range(1, 90)]
+        public int DuratioInDays { get; set; }
+        [Display(Name = "available from"), Required]
+        public DateTime? StartValidityDate { get; set; }
+        [Display(Name = "available to"), Required]
+        public DateTime? EndValidityDate { get; set; }
+        [Display(Name = "destination")]
+        public int DestinationId { get; set; }
+    }
+}

--- a/ch16/PackagesManagementBlazor/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
+++ b/ch16/PackagesManagementBlazor/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
@@ -1,0 +1,25 @@
+using PackagesManagementDomain.Aggregates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageInfosViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public int DuratioInDays { get; set; }
+        public DateTime? StartValidityDate { get; set; }
+        public DateTime? EndValidityDate { get; set; }
+        public string DestinationName { get; set; }
+        public int DestinationId { get; set; }
+        public override string ToString()
+        {
+            return string.Format("{0}. {1} days in {2}, price: {3}",
+                Name, DuratioInDays, DestinationName, Price);
+        }
+    }
+}

--- a/ch16/PackagesManagementBlazor/PackagesManagement/Models/Packages/PackagesListViewModel.cs
+++ b/ch16/PackagesManagementBlazor/PackagesManagement/Models/Packages/PackagesListViewModel.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackagesListViewModel
+    {
+        public IEnumerable<PackageInfosViewModel> Items { get; set; }
+    }
+}

--- a/ch18/PackagesManagementWithTests/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
+++ b/ch18/PackagesManagementWithTests/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
@@ -1,0 +1,45 @@
+using PackagesManagementDomain.Aggregates;
+using PackagesManagementDomain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageFullEditViewModel: IPackageFullEditDTO
+    {
+        public PackageFullEditViewModel() { }
+        public PackageFullEditViewModel(IPackage o)
+        {
+            Id = o.Id;
+            DestinationId = o.DestinationId;
+            Name = o.Name;
+            Description = o.Description;
+            Price = o.Price;
+            DurationInDays = o.DurationInDays;
+            StartValidityDate = o.StartValidityDate;
+            EndValidityDate = o.EndValidityDate;
+        }
+        public int Id { get; set; }
+        [StringLength(128, MinimumLength = 5), Required]
+        [Display(Name = "name")]
+        public string Name { get; set; }
+        [Display(Name = "package infos")]
+        [StringLength(128, MinimumLength = 10), Required]
+        public string Description { get; set; }
+        [Display(Name = "price")]
+        [Range(0, 100000)]
+        public decimal Price { get; set; }
+        [Display(Name = "duration in days")]
+        [Range(1, 90)]
+        public int DurationInDays { get; set; }
+        [Display(Name = "available from"), Required]
+        public DateTime? StartValidityDate { get; set; }
+        [Display(Name = "available to"), Required]
+        public DateTime? EndValidityDate { get; set; }
+        [Display(Name = "destination")]
+        public int DestinationId { get; set; }
+    }
+}

--- a/ch18/PackagesManagementWithTests/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
+++ b/ch18/PackagesManagementWithTests/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackagesListViewModel
+    {
+        public IEnumerable<PackageInfosViewModel> Items { get; set; }
+    }
+}

--- a/ch18/PackagesManagementWithTests/PackagesManagement/Models/Packages/PackagesListViewModel.cs
+++ b/ch18/PackagesManagementWithTests/PackagesManagement/Models/Packages/PackagesListViewModel.cs
@@ -1,0 +1,25 @@
+using PackagesManagementDomain.Aggregates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageInfosViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public int DurationInDays { get; set; }
+        public DateTime? StartValidityDate { get; set; }
+        public DateTime? EndValidityDate { get; set; }
+        public string DestinationName { get; set; }
+        public int DestinationId { get; set; }
+        public override string ToString()
+        {
+            return string.Format("{0}. {1} days in {2}, price: {3}",
+                Name, DurationInDays, DestinationName, Price);
+        }
+    }
+}

--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Models/Packages/PackageFullEditViewModel.cs
@@ -1,0 +1,45 @@
+using PackagesManagementDomain.Aggregates;
+using PackagesManagementDomain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageFullEditViewModel: IPackageFullEditDTO
+    {
+        public PackageFullEditViewModel() { }
+        public PackageFullEditViewModel(IPackage o)
+        {
+            Id = o.Id;
+            DestinationId = o.DestinationId;
+            Name = o.Name;
+            Description = o.Description;
+            Price = o.Price;
+            DurationInDays = o.DurationInDays;
+            StartValidityDate = o.StartValidityDate;
+            EndValidityDate = o.EndValidityDate;
+        }
+        public int Id { get; set; }
+        [StringLength(128, MinimumLength = 5), Required]
+        [Display(Name = "name")]
+        public string Name { get; set; }
+        [Display(Name = "package infos")]
+        [StringLength(128, MinimumLength = 10), Required]
+        public string Description { get; set; }
+        [Display(Name = "price")]
+        [Range(0, 100000)]
+        public decimal Price { get; set; }
+        [Display(Name = "duration in days")]
+        [Range(1, 90)]
+        public int DurationInDays { get; set; }
+        [Display(Name = "available from"), Required]
+        public DateTime? StartValidityDate { get; set; }
+        [Display(Name = "available to"), Required]
+        public DateTime? EndValidityDate { get; set; }
+        [Display(Name = "destination")]
+        public int DestinationId { get; set; }
+    }
+}

--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Models/Packages/PackageInfosViewModel.cs
@@ -1,0 +1,25 @@
+using PackagesManagementDomain.Aggregates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackageInfosViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public int DurationInDays { get; set; }
+        public DateTime? StartValidityDate { get; set; }
+        public DateTime? EndValidityDate { get; set; }
+        public string DestinationName { get; set; }
+        public int DestinationId { get; set; }
+        public override string ToString()
+        {
+            return string.Format("{0}. {1} days in {2}, price: {3}",
+                Name, DurationInDays, DestinationName, Price);
+        }
+    }
+}

--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Models/Packages/PackagesListViewModel.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Models/Packages/PackagesListViewModel.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PackagesManagement.Models.Packages
+{
+    public class PackagesListViewModel
+    {
+        public IEnumerable<PackageInfosViewModel> Items { get; set; }
+    }
+}


### PR DESCRIPTION
The default `.gitignore` patterns ignore almost everything in `Packages/`, so the previous cleanup removed some files that needed to be kept (sorry). I've restored them and updated the `.gitignore` file to _keep them_.