### PR TITLE
Remove use of async void when seeding the Db

### DIFF
--- a/ch15/PackagesManagement/PackagesManagement/Program.cs
+++ b/ch15/PackagesManagement/PackagesManagement/Program.cs
@@ -1,19 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using PackagesManagementDB;
+using PackagesManagementDB.Extensions;
+using System;
+using System.Threading.Tasks;
 
 namespace PackagesManagement
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            var host = CreateHostBuilder(args)
+                .Build();
+
+            await SeedDatabase(host.Services);
+            await host.RunAsync();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -22,5 +25,13 @@ namespace PackagesManagement
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        private static async Task SeedDatabase(IServiceProvider serviceProvider)
+        {
+            using var serviceScope = serviceProvider.CreateScope();
+            var context = serviceScope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+            await context.Seed(serviceScope);
+        }
     }
 }

--- a/ch15/PackagesManagement/PackagesManagement/Startup.cs
+++ b/ch15/PackagesManagement/PackagesManagement/Startup.cs
@@ -46,8 +46,7 @@ namespace PackagesManagement
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, 
-            IWebHostEnvironment env, IServiceProvider serviceProvider)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -93,7 +92,6 @@ namespace PackagesManagement
                     pattern: "{controller=Home}/{action=Index}/{id?}");
                 endpoints.MapRazorPages();
             });
-            app.UseDBLayer(serviceProvider);
         }
     }
 }

--- a/ch15/PackagesManagement/PackagesManagementDB/Extensions/DBExtensions.cs
+++ b/ch15/PackagesManagement/PackagesManagementDB/Extensions/DBExtensions.cs
@@ -1,19 +1,17 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using DDD.DomainLayer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using PackagesManagementDB.Models;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using DDD.DomainLayer;
 
 namespace PackagesManagementDB.Extensions
 {
     public static class DBExtensions
     {
-        public static IServiceCollection AddDbLayer(this IServiceCollection services, 
+        public static IServiceCollection AddDbLayer(this IServiceCollection services,
             string connectionString, string migrationAssembly)
         {
             services.AddDbContext<MainDbContext>(options =>
@@ -24,23 +22,15 @@ namespace PackagesManagementDB.Extensions
             services.AddAllRepositories(typeof(DBExtensions).Assembly);
             return services;
         }
-        public static async void UseDBLayer(this IApplicationBuilder app, IServiceProvider serviceProvider)
-        {
-            using (var serviceScope = serviceProvider.GetService<IServiceScopeFactory>().CreateScope())
-            {
-                var context = serviceScope.ServiceProvider.GetService<MainDbContext>();
-                context.Database.Migrate();
-                await Seed(context, serviceScope);
 
-            }
-        }
-        private static async Task Seed(MainDbContext context, IServiceScope serviceScope)
+        public static async Task Seed(this MainDbContext context, IServiceScope serviceScope)
         {
-            
-           if (!await context.Roles.AnyAsync())
+            await context.Database.MigrateAsync();
+
+            if (!await context.Roles.AnyAsync())
             {
                 var roleManager = serviceScope.ServiceProvider.GetService<RoleManager<IdentityRole<int>>>();
-                var role = new IdentityRole<int> { Name = "Admins"};
+                var role = new IdentityRole<int> { Name = "Admins" };
                 await roleManager.CreateAsync(role);
 
             }
@@ -88,6 +78,6 @@ namespace PackagesManagementDB.Extensions
                 await context.SaveChangesAsync();
             }
         }
-        
+
     }
 }

--- a/ch15/PackagesManagement/PackagesManagementDB/PackagesManagementDB.csproj
+++ b/ch15/PackagesManagement/PackagesManagementDB/PackagesManagementDB.csproj
@@ -1,9 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />


### PR DESCRIPTION
Seeding the database from `Main` allows the process to be completed without using `async void`. I've also changed the `PackagesManagementDB` project so that it's not a web project.