### PR TITLE
Updates for Chapter 22

### DIFF
--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Handlers/PackageDeleteEventHandler.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Handlers/PackageDeleteEventHandler.cs
@@ -1,11 +1,8 @@
 ﻿using DDD.ApplicationLayer;
+using PackagesManagementDomain.Aggregates;
 using PackagesManagementDomain.Events;
 using PackagesManagementDomain.IRepositories;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using PackagesManagementDomain.Aggregates;
 
 namespace PackagesManagement.Handlers
 {
@@ -17,9 +14,10 @@ namespace PackagesManagement.Handlers
         {
             this.repo = repo;
         }
-        public async Task HandleAsync(PackageDeleteEvent ev)
+        public Task HandleAsync(PackageDeleteEvent ev)
         {
             repo.New(PackageEventType.Deleted, ev.PackageId, ev.OldVersion);
+            return Task.CompletedTask;
         }
     }
 }

--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Handlers/PackagePriceChangedEventHandler.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Handlers/PackagePriceChangedEventHandler.cs
@@ -2,9 +2,6 @@
 using PackagesManagementDomain.Aggregates;
 using PackagesManagementDomain.Events;
 using PackagesManagementDomain.IRepositories;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace PackagesManagement.Handlers
@@ -17,9 +14,10 @@ namespace PackagesManagement.Handlers
         {
             this.repo = repo;
         }
-        public async Task HandleAsync(PackagePriceChangedEvent ev)
+        public Task HandleAsync(PackagePriceChangedEvent ev)
         {
             repo.New(PackageEventType.CostChanged, ev.PackageId, ev.OldVersion, ev.NewVersion, ev.NewPrice);
+            return Task.CompletedTask;
         }
     }
 }

--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Program.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Program.cs
@@ -1,19 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using PackagesManagementDB;
+using PackagesManagementDB.Extensions;
+using System;
+using System.Threading.Tasks;
 
 namespace PackagesManagement
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            var host = CreateHostBuilder(args)
+                .Build();
+
+            await SeedDatabase(host.Services);
+            await host.RunAsync();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -22,5 +25,13 @@ namespace PackagesManagement
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        private static async Task SeedDatabase(IServiceProvider serviceProvider)
+        {
+            using var serviceScope = serviceProvider.CreateScope();
+            var context = serviceScope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+            await context.Seed(serviceScope);
+        }
     }
 }

--- a/ch22/PackagesManagementWithUITests/PackagesManagement/Startup.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagement/Startup.cs
@@ -1,18 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using DDD.ApplicationLayer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using PackagesManagement.Queries;
 using PackagesManagementDB.Extensions;
+using System.Collections.Generic;
+using System.Globalization;
 
 namespace PackagesManagement
 {
@@ -46,8 +41,7 @@ namespace PackagesManagement
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, 
-            IWebHostEnvironment env, IServiceProvider serviceProvider)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -69,8 +63,8 @@ namespace PackagesManagement
 
             app.UseAuthentication();
             app.UseAuthorization();
-            
-            var ci = new CultureInfo("en-US");            
+
+            var ci = new CultureInfo("en-US");
 
             // Configure the Localization middleware
             app.UseRequestLocalization(new RequestLocalizationOptions
@@ -80,7 +74,7 @@ namespace PackagesManagement
                 {
                     ci,
                 },
-                            SupportedUICultures = new List<CultureInfo>
+                SupportedUICultures = new List<CultureInfo>
                 {
                     ci,
                 }
@@ -93,7 +87,6 @@ namespace PackagesManagement
                     pattern: "{controller=Home}/{action=Index}/{id?}");
                 endpoints.MapRazorPages();
             });
-            app.UseDBLayer(serviceProvider);
         }
     }
 }

--- a/ch22/PackagesManagementWithUITests/PackagesManagementDB/Extensions/DBExtensions.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagementDB/Extensions/DBExtensions.cs
@@ -1,19 +1,17 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using DDD.DomainLayer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using PackagesManagementDB.Models;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using DDD.DomainLayer;
 
 namespace PackagesManagementDB.Extensions
 {
     public static class DBExtensions
     {
-        public static IServiceCollection AddDbLayer(this IServiceCollection services, 
+        public static IServiceCollection AddDbLayer(this IServiceCollection services,
             string connectionString, string migrationAssembly)
         {
             services.AddDbContext<MainDbContext>(options =>
@@ -24,23 +22,15 @@ namespace PackagesManagementDB.Extensions
             services.AddAllRepositories(typeof(DBExtensions).Assembly);
             return services;
         }
-        public static async void UseDBLayer(this IApplicationBuilder app, IServiceProvider serviceProvider)
-        {
-            using (var serviceScope = serviceProvider.GetService<IServiceScopeFactory>().CreateScope())
-            {
-                var context = serviceScope.ServiceProvider.GetService<MainDbContext>();
-                context.Database.Migrate();
-                await Seed(context, serviceScope);
 
-            }
-        }
-        private static async Task Seed(MainDbContext context, IServiceScope serviceScope)
+        public static async Task Seed(this MainDbContext context, IServiceScope serviceScope)
         {
-            
-           if (!await context.Roles.AnyAsync())
+            await context.Database.MigrateAsync();
+
+            if (!await context.Roles.AnyAsync())
             {
                 var roleManager = serviceScope.ServiceProvider.GetService<RoleManager<IdentityRole<int>>>();
-                var role = new IdentityRole<int> { Name = "Admins"};
+                var role = new IdentityRole<int> { Name = "Admins" };
                 await roleManager.CreateAsync(role);
 
             }
@@ -88,6 +78,6 @@ namespace PackagesManagementDB.Extensions
                 await context.SaveChangesAsync();
             }
         }
-        
+
     }
 }

--- a/ch22/PackagesManagementWithUITests/PackagesManagementDB/MainDbContext.cs
+++ b/ch22/PackagesManagementWithUITests/PackagesManagementDB/MainDbContext.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using DDD.DomainLayer;
+﻿using DDD.DomainLayer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using PackagesManagementDB.Models;
+using System.Threading.Tasks;
 
 namespace PackagesManagementDB
 {
-    public class MainDbContext: IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, IUnitOfWork
+    public class MainDbContext : IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, IUnitOfWork
     {
         public DbSet<Package> Packages { get; set; }
         public DbSet<Destination> Destinations { get; set; }
@@ -48,9 +46,9 @@ namespace PackagesManagementDB
 
         public async Task<bool> SaveEntitiesAsync()
         {
-            
-            
-            
+
+
+
             try
             {
                 return await SaveChangesAsync() > 0;
@@ -60,12 +58,12 @@ namespace PackagesManagementDB
                 foreach (var entry in ex.Entries)
                 {
 
-                    entry.State = EntityState.Detached;                   
-                         
+                    entry.State = EntityState.Detached;
+
                 }
-                throw ex;
+                throw;
             }
-            
+
         }
 
         public async Task StartAsync()
@@ -73,14 +71,16 @@ namespace PackagesManagementDB
             await Database.BeginTransactionAsync();
         }
 
-        public async Task CommitAsync()
+        public Task CommitAsync()
         {
             Database.CommitTransaction();
+            return Task.CompletedTask;
         }
 
-        public async Task RollbackAsync()
+        public Task RollbackAsync()
         {
             Database.RollbackTransaction();
+            return Task.CompletedTask;
         }
     }
 }

--- a/ch22/PackagesManagementWithUITests/PackagesManagementDB/PackagesManagementDB.csproj
+++ b/ch22/PackagesManagementWithUITests/PackagesManagementDB/PackagesManagementDB.csproj
@@ -1,9 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />


### PR DESCRIPTION
- Convert Db project to non-web project.
- Remove use of `async void` when seeding the Db.
- Remove warnings for `async` without `await`.
- Rethrow exception with stack-trace.
- Fix formatting.