### PR TITLE
Updates for Chapter 12

### DIFF
--- a/ch12/ApplicationLayer/EventDIExtensions.cs
+++ b/ch12/ApplicationLayer/EventDIExtensions.cs
@@ -15,8 +15,8 @@ namespace DDD.ApplicationLayer
             where T : IEventNotification
             where H : class, IEventHandler<T>
         {
-            services.AddScoped<H>();
             services.TryAddScoped(typeof(EventTrigger<>));
+            services.AddScoped<IEventHandler<T>, H>();
 
             return services;
         }


### PR DESCRIPTION
The registration of the `IEventHandler<T>` implementation needs to be registered as `IEventHandler<T>` instead of the concrete type. Otherwise, the `IEnumerable<IEventHandler<T>>` passed into `EventTrigger`'s constructor is empty.

I'll submit another PR that makes this change across the other chapters once this one's been merged.